### PR TITLE
Fix upload modal progress tracking

### DIFF
--- a/frontend/src/services/uploadTracking/uploadTrackingService.jsx
+++ b/frontend/src/services/uploadTracking/uploadTrackingService.jsx
@@ -11,7 +11,8 @@ class UploadTrackingService {
     if (this.socket) {
       this.socket.disconnect();
     }
-    this.socket = socketService.connect(`http://localhost:5000?session_id=${sessionId}`);
+    socketService.connect(`http://localhost:5000/upload?session_id=${sessionId}`);
+    this.socket = socketService.socket;
     this.socket.on('connect', () => {
       console.log('Connected to upload WebSocket');
     });


### PR DESCRIPTION
## Summary
- connect to the `/upload` namespace when starting folder processing
- disconnect the websocket on completion or cancellation
- queue upload events from worker processes so the main app can emit them
- emit start and completion events with summary from SSE event handler

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6841bb37f8888332a68268d505412361