### PR TITLE
Fix upload modal progress tracking

### DIFF
--- a/backend/routes/file_processing_routes.py
+++ b/backend/routes/file_processing_routes.py
@@ -29,8 +29,10 @@ from functools import wraps
 # Import the refactored service and upload tracking emitters
 from services.file_processing_service import process_folder_task
 from utils.websockets.upload_tracking import (
+    emit_upload_started,
     emit_file_uploaded,
     emit_file_failed,
+    emit_upload_complete,
 )
 
 # -----------------------------------------------------------------------------
@@ -391,11 +393,6 @@ def stream_process_folder() -> Response:
                     # Cache files on the session so cleanup can work later
                     session.file_items = msg["scan"]
                     yield format_sse("scan", {"files": msg["scan"]})
-                elif "file" in msg:
-                    if msg["success"]:
-                        emit_file_uploaded(msg["session_id"], msg["file"])
-                    else:
-                        emit_file_failed(msg["session_id"], msg["file"], msg["error"])
                 elif "complete" in msg:
                     session.final = msg.get("summary", {})
                     yield format_sse("complete", session.final or {})

--- a/frontend/src/services/uploadTracking/uploadTrackingService.jsx
+++ b/frontend/src/services/uploadTracking/uploadTrackingService.jsx
@@ -11,7 +11,9 @@ class UploadTrackingService {
     if (this.socket) {
       this.socket.disconnect();
     }
-    this.socket = socketService.connect(`http://localhost:5000?session_id=${sessionId}`);
+    const port = this.store.getState().port.flaskPort || 5000;
+    socketService.connect(`http://localhost:${port}/upload?session_id=${sessionId}`);
+    this.socket = socketService.socket;
     this.socket.on('connect', () => {
       console.log('Connected to upload WebSocket');
     });


### PR DESCRIPTION
## Summary
- connect the upload WebSocket using the configured port
- emit upload progress events directly from the worker again
- remove bridging of these events through the SSE route

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6841bb37f8888332a68268d505412361